### PR TITLE
Fixes: Input with quotes or newlines makes the indexing panic

### DIFF
--- a/lib/sonic/channels/base.rb
+++ b/lib/sonic/channels/base.rb
@@ -29,7 +29,8 @@ module Sonic
       end
 
       def quote(value)
-        "\"#{value}\""
+        sanitized = value.gsub('"', '\\"').gsub(/[\r\n]+/, ' ')
+        "\"#{sanitized}\""
       end
 
       def type_cast_response(value)


### PR DESCRIPTION
This removes newlines and escapes double quotes.

---

Hey! I've just found Sonic and decided to play around with it. I've ran it against a content DB from me, but I've noticed that there are some indexing failures because of unescaped input.

