### PR TITLE
Normalize text input into search / ingest channels

### DIFF
--- a/lib/sonic/channels/base.rb
+++ b/lib/sonic/channels/base.rb
@@ -33,7 +33,7 @@ module Sonic
       end
 
       def sanitize(value)
-        value.gsub('"', '\\"').gsub(/[\r\n]+/, ' ')
+        value.gsub('"', '\\"').gsub(/[\r\n]+/, '\\n').gsub(/\\/, '\\\\')
       end
 
       def quote(value)

--- a/lib/sonic/channels/ingest.rb
+++ b/lib/sonic/channels/ingest.rb
@@ -2,14 +2,14 @@ module Sonic
   module Channels
     class Ingest < Base
       def push(collection, bucket, object, text, lang = nil)
-        arr = [collection, bucket, object, quote(text)]
+        arr = [collection, bucket, object, normalize(text)]
         arr << "LANG(#{lang})" if lang
 
         execute('PUSH', *arr)
       end
 
       def pop(collection, bucket, object, text)
-        execute('POP', collection, bucket, object, quote(text))
+        execute('POP', collection, bucket, object, normalize(text))
       end
 
       def count(collection, bucket = nil, object = nil)

--- a/lib/sonic/channels/search.rb
+++ b/lib/sonic/channels/search.rb
@@ -2,7 +2,7 @@ module Sonic
   module Channels
     class Search < Base
       def query(collection, bucket, terms, limit = nil, offset = nil, lang = nil) # rubocop:disable Metrics/ParameterLists, Metrics/LineLength
-        arr = [collection, bucket, quote(terms)]
+        arr = [collection, bucket, normalize(terms)]
         arr << "LIMIT(#{limit})" if limit
         arr << "OFFSET(#{offset})" if offset
         arr << "LANG(#{lang})" if lang
@@ -13,7 +13,7 @@ module Sonic
       end
 
       def suggest(collection, bucket, word, limit = nil)
-        arr = [collection, bucket, quote(word)]
+        arr = [collection, bucket, normalize(word)]
         arr << "LIMIT(#{limit})" if limit
 
         execute('SUGGEST', *arr) do


### PR DESCRIPTION
This fixes cases where you could ingest something like this:
```
ingest.push "all", "all", 1, "my text \" something"
```